### PR TITLE
Consider Local DB as the Source of Truth for Document Sync Status

### DIFF
--- a/Sources/DatabaseLayer/Records/Queries/QueryHelper.swift
+++ b/Sources/DatabaseLayer/Records/Queries/QueryHelper.swift
@@ -61,7 +61,7 @@ public final class QueryHelper {
   public static func fetchRecordsForEditedRecordSync() -> NSFetchRequest<Record> {
       let fetchRequest: NSFetchRequest<Record> = Record.fetchRequest()
       fetchRequest.predicate = NSPredicate(
-          format: "isEdited == %@ AND syncState == %@",
+          format: "isEdited == %@ AND (syncState == %@ OR syncState == nil)",
           NSNumber(value: true),
           RecordSyncState.upload(success: true).stringValue
       )

--- a/Sources/DatabaseLayer/Records/RecordDatabaseAdapter.swift
+++ b/Sources/DatabaseLayer/Records/RecordDatabaseAdapter.swift
@@ -253,7 +253,6 @@ extension RecordDatabaseAdapter {
       insertModel.isAbhaLinked = false
     }
     
-    insertModel.syncState = RecordSyncState.upload(success: true)
     /// Assign cases array if available
     insertModel.caseIDs = networkModel.recordDocument.item.cases
     /// Form Thumbnail asynchronously

--- a/Sources/DatabaseLayer/Records/RecordsRepo.swift
+++ b/Sources/DatabaseLayer/Records/RecordsRepo.swift
@@ -194,9 +194,6 @@ public final class RecordsRepo {
         case .uploadLimitReached, .unknown(message: _, statusCode: _):
           databaseManager.updateRecord(documentID: documentId, syncStatus: RecordSyncState.upload(success: false))
           didUploadRecord(nil, error)
-        case .duplicateDocumentUpload:
-          databaseManager.updateRecord(documentID: documentId, syncStatus: RecordSyncState.upload(success: true))
-          didUploadRecord(nil, error)
         default:
           deleteRecordV3(documentID: documentId, oid: record.oid ?? "") { [weak self] _, _ in
               self?.databaseManager.updateRecord(documentID: documentId, syncStatus: RecordSyncState.upload(success: false))

--- a/Sources/DatabaseLayer/Records/RecordsRepo.swift
+++ b/Sources/DatabaseLayer/Records/RecordsRepo.swift
@@ -135,8 +135,14 @@ public final class RecordsRepo {
         return
       }
       /// Upload to vault
-      self.uploadRecord(record: addedRecord) { record, errorType in
-        didAddRecord(record, errorType)
+      self.uploadRecord(record: addedRecord) { [weak self] uploadedRecord, errorType in
+        if uploadedRecord == nil, errorType?.isDocumentAlreadyUploaded == true {
+          self?.deleteRecordV3(documentID: addedRecord.documentID, oid: addedRecord.oid ?? "") { _, _ in
+            didAddRecord(nil, errorType)
+          }
+        } else {
+          didAddRecord(uploadedRecord, errorType)
+        }
       }
     }
   }
@@ -190,16 +196,8 @@ public final class RecordsRepo {
       }
       
       guard error == nil, let uploadFormsResponse else {
-        switch error {
-        case .uploadLimitReached, .unknown(message: _, statusCode: _):
-          databaseManager.updateRecord(documentID: documentId, syncStatus: RecordSyncState.upload(success: false))
-          didUploadRecord(nil, error)
-        default:
-          deleteRecordV3(documentID: documentId, oid: record.oid ?? "") { [weak self] _, _ in
-              self?.databaseManager.updateRecord(documentID: documentId, syncStatus: RecordSyncState.upload(success: false))
-              didUploadRecord(nil, error)
-            }
-        }
+        databaseManager.updateRecord(documentID: documentId, syncStatus: RecordSyncState.upload(success: false))
+        didUploadRecord(nil, error)
         return
       }
       
@@ -652,18 +650,48 @@ extension RecordsRepo {
           
           for record in records {
               uploadGroup.enter()
-            self.uploadRecord(record: record) { uploadedRecord, errorType in
-                  if uploadedRecord == nil {
-                      let uploadError = ErrorHelper.createError(
-                          domain: .sync,
-                          code: errorType?.isUploadLimitReached ?? false ? .uploadLimitReached : .networkRequestFailed ,
-                          message: "Failed to upload record: \(record.documentID ?? "unknown")"
-                      )
-                      errorsQueue.async(flags: .barrier) {
-                          errors.append(uploadError)
-                      }
+            self.uploadRecord(record: record) { [weak self] uploadedRecord, errorType in
+                  guard let self else {
+                      uploadGroup.leave()
+                      return
                   }
-                  uploadGroup.leave()
+                  if uploadedRecord == nil, errorType?.isDocumentAlreadyUploaded == true {
+                      self.deleteRecordV3(documentID: record.documentID, oid: record.oid ?? "") { [weak self] success, _ in
+                          guard success else {
+                              uploadGroup.leave()
+                              return
+                          }
+                          guard let self else {
+                              uploadGroup.leave()
+                              return
+                          }
+                          self.uploadRecord(record: record) { retryRecord, retryError in
+                              if retryRecord == nil {
+                                  let uploadError = ErrorHelper.createError(
+                                      domain: .sync,
+                                      code: retryError?.isUploadLimitReached ?? false ? .uploadLimitReached : .networkRequestFailed,
+                                      message: "Failed to upload record after duplicate cleanup: \(record.documentID ?? "unknown")"
+                                  )
+                                  errorsQueue.async(flags: .barrier) {
+                                      errors.append(uploadError)
+                                  }
+                              }
+                              uploadGroup.leave()
+                          }
+                      }
+                  } else {
+                      if uploadedRecord == nil {
+                          let uploadError = ErrorHelper.createError(
+                              domain: .sync,
+                              code: errorType?.isUploadLimitReached ?? false ? .uploadLimitReached : .networkRequestFailed,
+                              message: "Failed to upload record: \(record.documentID ?? "unknown")"
+                          )
+                          errorsQueue.async(flags: .barrier) {
+                              errors.append(uploadError)
+                          }
+                      }
+                      uploadGroup.leave()
+                  }
               }
           }
           


### PR DESCRIPTION
fix: handle duplicate upload errors correctly across add and sync flows

.Consider Local DB as the Source of Truth for Document Sync Status
   • uploadRecord no longer incorrectly marks 409 responses as upload(success: true); all errors now mark as upload(success: false)
   • addSingleRecord deletes the stale server copy when a duplicate is detected before surfacing the error
   • syncNewRecords deletes the stale server copy on duplicate then retries the upload inline; fixes potential infinite retry loop